### PR TITLE
Add reference to plugin dragdata

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ A curated list of awesome things related to [Chart.js](https://www.chartjs.org) 
 - [crosshair](https://github.com/abelheinsbroek/chartjs-plugin-crosshair) - Adds a data crosshair to line and scatter charts.
 - [datalabels](https://github.com/chartjs/chartjs-plugin-datalabels) - Displays labels on data for any type of charts.
 - [deferred](https://github.com/chartjs/chartjs-plugin-deferred) -  Defers initial chart update until chart scrolls into viewport.
+- [dragData](https://github.com/chrispahm/chartjs-plugin-dragData) - Lets users drag data points on the chart.
 - [rough](https://github.com/nagix/chartjs-plugin-rough) - Draws charts in a sketchy, hand-drawn-like style using Rough.js.
 - [stacked100](https://github.com/y-takey/chartjs-plugin-stacked100) - Draws 100% stacked bar chart.
 - [streaming](https://github.com/nagix/chartjs-plugin-streaming) - Adds support for live streaming data.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ A curated list of awesome things related to [Chart.js](https://www.chartjs.org) 
 - [crosshair](https://github.com/abelheinsbroek/chartjs-plugin-crosshair) - Adds a data crosshair to line and scatter charts.
 - [datalabels](https://github.com/chartjs/chartjs-plugin-datalabels) - Displays labels on data for any type of charts.
 - [deferred](https://github.com/chartjs/chartjs-plugin-deferred) -  Defers initial chart update until chart scrolls into viewport.
-- [dragData](https://github.com/chrispahm/chartjs-plugin-dragData) - Lets users drag data points on the chart.
+- [dragdata](https://github.com/chrispahm/chartjs-plugin-dragdata) - Lets users drag data points on the chart.
 - [rough](https://github.com/nagix/chartjs-plugin-rough) - Draws charts in a sketchy, hand-drawn-like style using Rough.js.
 - [stacked100](https://github.com/y-takey/chartjs-plugin-stacked100) - Draws 100% stacked bar chart.
 - [streaming](https://github.com/nagix/chartjs-plugin-streaming) - Adds support for live streaming data.


### PR DESCRIPTION
<!--
  Thank you for contributing to our awesome list!
  Please make sure you check each box below ( [x] ) after you have
  completed or verified the step. Please do not skip this template
  or your issue will be closed (and we'd rather not do that).

  Maintainers may disregard this template for organizational Pull Requests.
-->

Awesome Contribution Checklist:

<!-- *** If you do not abide by the Contributing Guidelines, your Pull Request WILL BE CLOSED -->

- [x] I have read, and re-read the [Contributing Guidelines](https://github.com/chartjs/awesome/blob/master/CONTRIBUTING.md)
- [x] I have searched to ensure the suggested item doesn't exist on this list
- [x] This PR contains only one item

### Please Describe Your Addition

This PR adds a reference to [chartjs-plugin-dragdata](https://github.com/chrispahm/chartjs-plugin-dragdata), which allow users to drag data points on a chart.

![plugin-dragdata demo](https://raw.githubusercontent.com/chrispahm/chartjs-plugin-dragData/de548d4619a9e2253dc50a3fd6092ff15a99f07e/docs/assets/chartjs-plugin-dragData.gif)
