### PR TITLE
Remove unmaintained angular-chart.js integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,6 @@ In addition, many plugins can be found on the [npm registry](https://www.npmjs.c
 
 ### JavaScript
 
-- [angular-chart.js](https://github.com/jtblin/angular-chart.js) - Angular v1
 - [angular2-chartjs](https://github.com/emn178/angular2-chartjs) - Angular v2+
 - [ember-cli-chart](https://github.com/aomran/ember-cli-chart) - Ember CLI
 - [ng2-charts](https://github.com/valor-software/ng2-charts) - Angular v2+


### PR DESCRIPTION
It looks like this plugin is very outdated and causing problems for users. See https://github.com/jtblin/angular-chart.js/issues/712 and https://github.com/chartjs/Chart.js/issues/6464