### PR TITLE
add link to chartsjs-chart-error-bars

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ A curated list of awesome things related to [Chart.js](https://www.chartjs.org) 
 
 - [bar-funnel](https://github.com/chartjs/Chart.BarFunnel.js) - Adds bar funnel chart type.
 - [boxplot](https://github.com/datavisyn/chartjs-chart-box-and-violin-plot) - Adds boxplot and violin plot chart type.
+- [error-bars](https://github.com/sgratzl/chartjs-chart-error-bars) - Adds diverse error bar variants of standard chart types.
 - [financial](https://github.com/chartjs/chartjs-chart-financial) - Adds financial chart types such as a candlestick.
 - [matrix](https://github.com/kurkle/chartjs-chart-matrix) - Adds matrix chart type.
 - [smith](https://github.com/chartjs/Chart.smith.js) - Adds smith chart type.


### PR DESCRIPTION
<!--
  Thank you for contributing to our awesome list!
  Please make sure you check each box below ( [x] ) after you have
  completed or verified the step. Please do not skip this template
  or your issue will be closed (and we'd rather not do that).

  Maintainers may disregard this template for organizational Pull Requests.
-->

Awesome Contribution Checklist:

<!-- *** If you do not abide by the Contributing Guidelines, your Pull Request WILL BE CLOSED -->

- [x] I have read, and re-read the [Contributing Guidelines](https://github.com/chartjs/awesome/blob/master/CONTRIBUTING.md)
- [x] I have searched to ensure the suggested item doesn't exist on this list
- [x] This PR contains only one item

### Please Describe Your Addition

add a link to the https://github.com/sgratzl/chartjs-chart-error-bars plugin for rendering error-bars onto all the standard chart types (bar, line, scatter, horizontalBar, polarArea)

![bar char with error bars](https://user-images.githubusercontent.com/4129778/65203797-1a9e3b00-da5a-11e9-9de7-9cbcf75dfeda.png)

![scatter plot with error bars](https://user-images.githubusercontent.com/4129778/65203792-1a05a480-da5a-11e9-9073-6e849d42af64.png)

![polar area plot with error bars](https://user-images.githubusercontent.com/4129778/65203794-1a05a480-da5a-11e9-9b17-316ecc6ae0d9.png)

Note: this is new implementation of the https://github.com/chartjs/awesome/pull/3 plugin based on extending existing chart types than injecting error bars.
