### PR TITLE
switch to my maintained fork of chartjs-chart-boxplot

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ A curated list of awesome things related to [Chart.js](https://www.chartjs.org) 
 ## Charts
 
 - [bar-funnel](https://github.com/chartjs/Chart.BarFunnel.js) - Adds bar funnel chart type.
-- [boxplot](https://github.com/datavisyn/chartjs-chart-box-and-violin-plot) - Adds boxplot and violin plot chart type.
+- [boxplot](https://github.com/sgratzl/chartjs-chart-boxplot) - Adds boxplot and violin plot chart type.
 - [error-bars](https://github.com/sgratzl/chartjs-chart-error-bars) - Adds diverse error bar variants of standard chart types.
 - [financial](https://github.com/chartjs/chartjs-chart-financial) - Adds financial chart types such as a candlestick.
 - [geo](https://github.com/sgratzl/chartjs-chart-geo) - Adds geographic map chart types such as choropleth and bubble map.


### PR DESCRIPTION
Awesome Contribution Checklist:

<!-- *** If you do not abide by the Contributing Guidelines, your Pull Request WILL BE CLOSED -->

- [x] I have read, and re-read the [Contributing Guidelines](https://github.com/chartjs/awesome/blob/master/CONTRIBUTING.md)
- [x] I have searched to ensure the suggested item doesn't exist on this list
- [x] This PR contains only one item

### Please Describe Your Addition

changes the boxplot reference to my fork. The original https://github.com/datavisyn/chartjs-chart-box-and-violin-plot hasn't been released in over a year and is not compatible with chart.js 3.

My fork at https://github.com/sgratzl/chartjs-chart-boxplot is maintained and ready for chart.js 3
