### PR TITLE
Remove angular2-chartjs as being unmaintained

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,6 @@ In addition, many plugins can be found on the [npm registry](https://www.npmjs.c
 
 ### JavaScript
 
-- [angular2-chartjs](https://github.com/emn178/angular2-chartjs) - Angular v2+
 - [ember-cli-chart](https://github.com/aomran/ember-cli-chart) - Ember CLI
 - [lwcc](https://github.com/SalesforceLabs/LightningWebChartJS) - Lightning Web Component
 - [ng2-charts](https://github.com/valor-software/ng2-charts) - Angular v2+


### PR DESCRIPTION
There are other angular alternatives on the list that have been more recently updated