### PR TITLE
Remove omi-chart as being missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,6 @@ In addition, many plugins can be found on the [npm registry](https://www.npmjs.c
 - [ember-cli-chart](https://github.com/aomran/ember-cli-chart) - Ember CLI
 - [lwcc](https://github.com/SalesforceLabs/LightningWebChartJS) - Lightning Web Component
 - [ng2-charts](https://github.com/valor-software/ng2-charts) - Angular v2+
-- [omi-chart](https://github.com/Tencent/omi/tree/master/packages/omi-chart) - Omi
 - [react-chartjs-2](https://github.com/jerairrest/react-chartjs-2) - React
 - [vue-chartjs](https://github.com/apertureless/vue-chartjs/) - Vue.js
 


### PR DESCRIPTION
<!--
  Thank you for contributing to our awesome list!
  Please make sure you check each box below ( [x] ) after you have
  completed or verified the step. Please do not skip this template
  or your issue will be closed (and we'd rather not do that).

  Maintainers may disregard this template for organizational Pull Requests.
-->

Awesome Contribution Checklist:

<!-- *** If you do not abide by the Contributing Guidelines, your Pull Request WILL BE CLOSED -->

- [x] I have read, and re-read the [Contributing Guidelines](https://github.com/chartjs/awesome/blob/master/CONTRIBUTING.md)
- [x] I have searched to ensure the suggested item doesn't exist on this list
- [x] This PR contains only one item

### Please Describe Your Addition

I was checking the items in this list and learned that the link to `omi-chart` is broken. I searched its repository and wasn't able to find out when it was removed. Maybe we can remove it from this list for now.