### PR TITLE
Remove V3 compatiability of colorschemes

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ A curated list of awesome things related to [Chart.js](https://www.chartjs.org)
   ---- | ----------- | :--: | :--:
   [annotation](https://github.com/chartjs/chartjs-plugin-annotation) | Draws lines and boxes on the chart area | ✔ | ✔
   [autocolors](https://github.com/kurkle/chartjs-plugin-autocolors) | Automatic color generation | | ✔
-  [colorschemes](https://github.com/nagix/chartjs-plugin-colorschemes) | Enables automatic coloring using predefined color schemes | ✔ | ✔
+  [colorschemes](https://github.com/nagix/chartjs-plugin-colorschemes) | Enables automatic coloring using predefined color schemes | ✔ | 
   [crosshair](https://github.com/abelheinsbroek/chartjs-plugin-crosshair) | Adds a data crosshair to line and scatter charts | ✔ | ✔
   [datalabels](https://github.com/chartjs/chartjs-plugin-datalabels) | Displays labels on data for any type of charts | ✔ | ✔
   [datasource-prometheus](https://github.com/samber/chartjs-plugin-datasource-prometheus) | Displays time-series from Prometheus | ✔ |


### PR DESCRIPTION
Colorschemes plugin is not compattible with V3.

Issue about it: https://github.com/nagix/chartjs-plugin-colorschemes/issues/28
Open PR for improving V3 compatability: https://github.com/nagix/chartjs-plugin-colorschemes/pull/30

<!--
  Thank you for contributing to our awesome list!
  Please make sure you check each box below ( [x] ) after you have
  completed or verified the step. Please do not skip this template
  or your issue will be closed (and we'd rather not do that).

  Maintainers may disregard this template for organizational Pull Requests.
-->

Awesome Contribution Checklist:

<!-- *** If you do not abide by the Contributing Guidelines, your Pull Request WILL BE CLOSED -->

- [ ] I have read, and re-read the [Contributing Guidelines](https://github.com/chartjs/awesome/blob/master/CONTRIBUTING.md)
- [ ] I have searched to ensure the suggested item doesn't exist on this list
- [x] This PR contains only one item

### Please Describe Your Addition
