### PR TITLE
Update ng2-charts compatibility for V3

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ In addition, many plugins can be found on the [npm registry](https://www.npmjs.c
   ---- | ----------- | :--: | :--:
   [ember-cli-chart](https://github.com/aomran/ember-cli-chart) | Ember CLI | ✔ |
   [lwcc](https://github.com/SalesforceLabs/LightningWebChartJS) | Lightning Web Component | ✔ |
-  [ng2-charts](https://github.com/valor-software/ng2-charts) | Angular v2+ | ✔ |
+  [ng2-charts](https://github.com/valor-software/ng2-charts) | Angular v2+ | ✔ | ✔
   [omi-chart](https://github.com/Tencent/omi/tree/master/components/chart) | Omi | ✔ | ✔
   [react-chartjs-2](https://github.com/jerairrest/react-chartjs-2) | React | ✔ | ✔
   [vue-chartjs](https://github.com/apertureless/vue-chartjs/) | Vue.js | ✔ |


### PR DESCRIPTION
Since release 3.0.0 a month ago the angular wrapper is compatible with chart.js v3: https://github.com/valor-software/ng2-charts/releases/tag/v3.0.0


