### PR TITLE
Add Charba support to v2 because missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ In addition, many plugins can be found on the [npm registry](https://www.npmjs.c
 
   Name | Description | Chart.js v2 | Chart.js v3
   ---- | ----------- | :--: | :--:
-  [charba](https://github.com/pepstock-org/Charba) | GWT/J2CL | | ✔
+  [charba](https://github.com/pepstock-org/Charba) | GWT/J2CL | ✔ | ✔
   [chart.java](https://github.com/mdewilde/chart/) | Java | ✔ |
   [chartjs-ocaml](https://github.com/monstasat/chartjs-ocaml) | OCaml | ✔ |
   [chartjs-ror](https://github.com/airblade/chartjs-ror) | Ruby on Rails | ✔ |


### PR DESCRIPTION
<!--
  Thank you for contributing to our awesome list!
  Please make sure you check each box below ( [x] ) after you have
  completed or verified the step. Please do not skip this template
  or your issue will be closed (and we'd rather not do that).

  Maintainers may disregard this template for organizational Pull Requests.
-->

Awesome Contribution Checklist:

<!-- *** If you do not abide by the Contributing Guidelines, your Pull Request WILL BE CLOSED -->

- [x] I have read, and re-read the [Contributing Guidelines](https://github.com/chartjs/awesome/blob/master/CONTRIBUTING.md)
- [x] I have searched to ensure the suggested item doesn't exist on this list
- [x] This PR contains only one item

### Please Describe Your Addition

CHARBA was born with CHART.JS 2.x and it's supported till version 3.3. Since 4.0 till now is including CHART.JS 3.x

https://pepstock-org.github.io/Charba-Wiki/docs/Requirements#chartjs-core
