### PR TITLE
Added `vue-chart-3` to javascript integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ In addition, many plugins can be found on the [npm registry](https://www.npmjs.c
   [omi-chart](https://github.com/Tencent/omi/tree/master/components/chart) | Omi | ✔ | ✔
   [react-chartjs-2](https://github.com/jerairrest/react-chartjs-2) | React | ✔ | ✔
   [vue-chartjs](https://github.com/apertureless/vue-chartjs/) | Vue.js | ✔ |
+  [vue-chart-3](https://github.com/victorgarciaesgi/vue-chart-3) | Vue.js 3 & 2 | | ✔
 
 ### Others
 


### PR DESCRIPTION
Awesome Contribution Checklist:

- [x] I have read, and re-read the [Contributing Guidelines](https://github.com/chartjs/awesome/blob/master/CONTRIBUTING.md)
- [x] I have searched to ensure the suggested item doesn't exist on this list
- [x] This PR contains only one item

### Please Describe Your Addition

`vue-chart-3` is around for nearly 10 months and has proven maturity in being `vue-chartjs` successor by adding Typescript safety, Vue 3 and Chart.js 3 support.
