### PR TITLE
Add V3 support for deferred plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ A curated list of awesome things related to [Chart.js](https://www.chartjs.org)
   [crosshair](https://github.com/abelheinsbroek/chartjs-plugin-crosshair) | Adds a data crosshair to line and scatter charts | ✔ | ✔
   [datalabels](https://github.com/chartjs/chartjs-plugin-datalabels) | Displays labels on data for any type of charts | ✔ | ✔
   [datasource-prometheus](https://github.com/samber/chartjs-plugin-datasource-prometheus) | Displays time-series from Prometheus | ✔ |
-  [deferred](https://github.com/chartjs/chartjs-plugin-deferred) | Defers initial chart update until chart scrolls into viewport | ✔ |
+  [deferred](https://github.com/chartjs/chartjs-plugin-deferred) | Defers initial chart update until chart scrolls into viewport | ✔ | ✔
   [dragdata](https://github.com/chrispahm/chartjs-plugin-dragdata) | Lets users drag data points on the chart | ✔ | ✔
   [gradient](https://github.com/kurkle/chartjs-plugin-gradient) | Easy gradients | | ✔
   [hierarchical](https://github.com/sgratzl/chartjs-plugin-hierarchical) | Adds support for hierarchical categorical scales that can be collapsed, expanded, and focused | ✔ | ✔


### PR DESCRIPTION
<!--
  Thank you for contributing to our awesome list!
  Please make sure you check each box below ( [x] ) after you have
  completed or verified the step. Please do not skip this template
  or your issue will be closed (and we'd rather not do that).

  Maintainers may disregard this template for organizational Pull Requests.
-->

Awesome Contribution Checklist:

<!-- *** If you do not abide by the Contributing Guidelines, your Pull Request WILL BE CLOSED -->

- [x] This PR contains only one item
- [x] I have read, and re-read the [Contributing Guidelines](https://github.com/chartjs/awesome/blob/master/CONTRIBUTING.md)
- [x] I have searched to ensure the suggested item doesn't exist on this list

### Please Describe Your Addition
Deferred plugin now supports Chart.js V3 with the release of V2 of deferred:
https://github.com/chartjs/chartjs-plugin-deferred/releases/tag/v2.0.0