### PR TITLE
docs: remove vue-chart-3 from wrappers list

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,6 @@ In addition, many plugins can be found on the [npm registry](https://www.npmjs.c
   [omi-chart](https://github.com/Tencent/omi/tree/master/components/chart) | Omi | ✔ | ✔
   [react-chartjs-2](https://github.com/jerairrest/react-chartjs-2) | React | ✔ | ✔
   [vue-chartjs](https://github.com/apertureless/vue-chartjs/) | Vue.js | ✔ | ✔
-  [vue-chart-3](https://github.com/victorgarciaesgi/vue-chart-3) | Vue.js 3 & 2 | | ✔
 
 ### Others
 


### PR DESCRIPTION
Awesome Contribution Checklist:

<!-- *** If you do not abide by the Contributing Guidelines, your Pull Request WILL BE CLOSED -->

- [x] I have read, and re-read the [Contributing Guidelines](https://github.com/chartjs/awesome/blob/master/CONTRIBUTING.md)
- [x] I have searched to ensure the suggested item doesn't exist on this list
- [x] This PR contains only one item

### Please Describe Your Addition

Hi folks!
I'm Slava, and I'm a collaborator of vue-chartjs.
As you can see [in the vue-chart-3 readme](https://github.com/victorgarciaesgi/vue-chart-3#im-joining-vue-chartjs-as-a-core-maintainer-so-this-package-will-be-kept-just-for-those-who-already-use-it-im-encouraging-new-users-to-use-vue-chartjs-instead), @victorgarciaesgi  has become part of the vue-chartjs team.

Together we are moving towards one Chart.js wrapper for the Vue ecosystem.
Victor will confirm that this PR is legal and I'm not trying to get rid of competitors))
