### PR TITLE
Arrange plugins by type

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ A curated list of awesome things related to [Chart.js](https://www.chartjs.org)
 
 ## Plugins
 
-### Colors and styles
+### Styling
 
   Name | Description | Chart.js v2 | Chart.js v3
   ---- | ----------- | :--: | :--:
@@ -67,7 +67,7 @@ A curated list of awesome things related to [Chart.js](https://www.chartjs.org)
   [dragdata](https://github.com/chrispahm/chartjs-plugin-dragdata) | Lets users drag data points on the chart | ✔ | ✔
   [zoom](https://github.com/chartjs/chartjs-plugin-zoom) | Enables zooming and panning on charts | ✔ | ✔
 
-### Data sources
+### Data Sources
 
   Name | Description | Chart.js v2 | Chart.js v3
   ---- | ----------- | :--: | :--:

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ A curated list of awesome things related to [Chart.js](https://www.chartjs.org)
   [rough](https://github.com/nagix/chartjs-plugin-rough) | Draws charts in a sketchy, hand-drawn-like style using Rough.js | ✔ |
   [style](https://github.com/nagix/chartjs-plugin-style) | Provides styling options such as shadow, bevel, glow or overlay effects | ✔ |
 
-### Chart elements
+### Features
 
   Name | Description | Chart.js v2 | Chart.js v3
   ---- | ----------- | :--: | :--:

--- a/README.md
+++ b/README.md
@@ -31,31 +31,48 @@ A curated list of awesome things related to [Chart.js](https://www.chartjs.org)
   [pcp](https://github.com/sgratzl/chartjs-chart-pcp) | Adds parallel coordinates plot chart type | ✔ | ✔
   [sankey](https://github.com/kurkle/chartjs-chart-sankey) | Adds sankey diagram chart type | | ✔
   [smith](https://github.com/chartjs/Chart.smith.js) | Adds smith chart type | ✔ |
+  [stacked100](https://github.com/y-takey/chartjs-plugin-stacked100) | Draws 100% stacked bar chart | ✔ | ✔
   [treemap](https://github.com/kurkle/chartjs-chart-treemap) | Adds treemap chart type | ✔ | ✔
   [venn](https://github.com/upsetjs/chartjs-chart-venn) | Adds venn and euler chart type | | ✔
   [word-cloud](https://github.com/sgratzl/chartjs-chart-wordcloud) | Adds word-cloud chart type | | ✔
 
 ## Plugins
 
+### Colors and styles
+
+  Name | Description | Chart.js v2 | Chart.js v3
+  ---- | ----------- | :--: | :--:
+  [autocolors](https://github.com/kurkle/chartjs-plugin-autocolors) | Automatic color generation | | ✔
+  [colorschemes](https://github.com/nagix/chartjs-plugin-colorschemes) | Enables automatic coloring using predefined color schemes | ✔ | 
+  [gradient](https://github.com/kurkle/chartjs-plugin-gradient) | Easy gradients | | ✔
+  [rough](https://github.com/nagix/chartjs-plugin-rough) | Draws charts in a sketchy, hand-drawn-like style using Rough.js | ✔ |
+  [style](https://github.com/nagix/chartjs-plugin-style) | Provides styling options such as shadow, bevel, glow or overlay effects | ✔ |
+
+### Chart elements
+
   Name | Description | Chart.js v2 | Chart.js v3
   ---- | ----------- | :--: | :--:
   [annotation](https://github.com/chartjs/chartjs-plugin-annotation) | Draws lines and boxes on the chart area | ✔ | ✔
-  [autocolors](https://github.com/kurkle/chartjs-plugin-autocolors) | Automatic color generation | | ✔
-  [colorschemes](https://github.com/nagix/chartjs-plugin-colorschemes) | Enables automatic coloring using predefined color schemes | ✔ | 
   [crosshair](https://github.com/abelheinsbroek/chartjs-plugin-crosshair) | Adds a data crosshair to line and scatter charts | ✔ | ✔
   [datalabels](https://github.com/chartjs/chartjs-plugin-datalabels) | Displays labels on data for any type of charts | ✔ | ✔
-  [datasource-prometheus](https://github.com/samber/chartjs-plugin-datasource-prometheus) | Displays time-series from Prometheus | ✔ |
-  [deferred](https://github.com/chartjs/chartjs-plugin-deferred) | Defers initial chart update until chart scrolls into viewport | ✔ | ✔
-  [dragdata](https://github.com/chrispahm/chartjs-plugin-dragdata) | Lets users drag data points on the chart | ✔ | ✔
-  [gradient](https://github.com/kurkle/chartjs-plugin-gradient) | Easy gradients | | ✔
   [hierarchical](https://github.com/sgratzl/chartjs-plugin-hierarchical) | Adds support for hierarchical categorical scales that can be collapsed, expanded, and focused | ✔ | ✔
   [regression](https://github.com/pomgui/chartjs-plugin-regression) | Calculate and draw statistical linear, exponential, power, logarithmic, and polynomial regressions (trend lines) | ✔ |
-  [rough](https://github.com/nagix/chartjs-plugin-rough) | Draws charts in a sketchy, hand-drawn-like style using Rough.js | ✔ |
-  [stacked100](https://github.com/y-takey/chartjs-plugin-stacked100) | Draws 100% stacked bar chart | ✔ | ✔
-  [streaming](https://github.com/nagix/chartjs-plugin-streaming) | Adds support for live streaming data | ✔ | ✔
-  [style](https://github.com/nagix/chartjs-plugin-style) | Provides styling options such as shadow, bevel, glow or overlay effects | ✔ |
   [waterfall](https://github.com/everestate/chartjs-plugin-waterfall) | Enables easy use of waterfall charts | ✔ |
+
+### Interactions
+
+  Name | Description | Chart.js v2 | Chart.js v3
+  ---- | ----------- | :--: | :--:
+  [deferred](https://github.com/chartjs/chartjs-plugin-deferred) | Defers initial chart update until chart scrolls into viewport | ✔ | ✔
+  [dragdata](https://github.com/chrispahm/chartjs-plugin-dragdata) | Lets users drag data points on the chart | ✔ | ✔
   [zoom](https://github.com/chartjs/chartjs-plugin-zoom) | Enables zooming and panning on charts | ✔ | ✔
+
+### Data sources
+
+  Name | Description | Chart.js v2 | Chart.js v3
+  ---- | ----------- | :--: | :--:
+  [datasource-prometheus](https://github.com/samber/chartjs-plugin-datasource-prometheus) | Displays time-series from Prometheus | ✔ |
+  [streaming](https://github.com/nagix/chartjs-plugin-streaming) | Adds support for live streaming data | ✔ | ✔
 
 In addition, many plugins can be found on the [npm registry](https://www.npmjs.com/search?q=chartjs-plugin-).
 


### PR DESCRIPTION
Awesome Contribution Checklist:

<!-- *** If you do not abide by the Contributing Guidelines, your Pull Request WILL BE CLOSED -->

- [x] I have read, and re-read the [Contributing Guidelines](https://github.com/chartjs/awesome/blob/master/CONTRIBUTING.md)
- [x] I have searched to ensure the suggested item doesn't exist on this list
- [ ] This PR contains only one item

### Please Describe Your Addition

Following the conversation in this PR (https://github.com/chartjs/Chart.js/pull/10764), I've rearranged the list of plugins by type so it's easier to navigate through it and look for relevant plugins.

@LeeLenaleee @kurkle @etimberg @simonbrunel I'd like to know what you folks think.

Also, I think we can probably remove some of barely used items from this list. Take `chartjs-plugin-waterfall` that has only 353 weekly downloads on npm.