### PR TITLE
chore: Remove clearly unmaintained libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,12 +111,10 @@ In addition, many plugins can be found on the [npm registry](https://www.npmjs.c
   2️⃣ 3️⃣ ❕ | [charba](https://github.com/pepstock-org/Charba) | GWT/J2CL
   2️⃣ ❕ ❕ | [chart.java](https://github.com/mdewilde/chart/) | Java
   2️⃣ ❕ ❕ | [chartjs-ocaml](https://github.com/monstasat/chartjs-ocaml) | OCaml
-  2️⃣ ❕ ❕ | [chartjs-ror](https://github.com/airblade/chartjs-ror) | Ruby on Rails
   ❕ 3️⃣ 4️⃣ | [chart-js-rs](https://github.com/Billy-Sheppard/chart-js-rs) | Chart.js types API in Rust (WIP in Alpha/incomplete)
   2️⃣ ❕ ❕ | [django-chartjs](https://github.com/peopledoc/django-chartjs) | Django
   &nbsp; | [figma](https://www.figma.com/community/file/1111335120507995139) | Design components
   2️⃣ ❕ ❕ | [ipychart](https://github.com/nicohlr/ipychart) | Jupyter Notebook
-  2️⃣ ❕ ❕ | [laravel-chartjs](https://github.com/fxcosta/laravel-chartjs) | Laravel
   2️⃣ ❕ ❕ | [liquify](https://github.com/sakos95/liquify) | Fast, multi-threaded visualization of stream data with Angular
   2️⃣ ❕ ❕ | [nova-chartjs](https://github.com/coroo/nova-chartjs) | Laravel Nova
   2️⃣ 3️⃣ ❕ | [quickchart](https://github.com/typpo/quickchart) | Web API for static charts


### PR DESCRIPTION
As stated on the following pages, these two libraries are clearly unmaintained (and don't support v3/v4):
* https://github.com/fxcosta/laravel-chartjs
* https://github.com/airblade/chartjs-ror/issues/53