### PR TITLE
feat: add chartjs-plugin-a11y-legend

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ A curated list of awesome things related to [Chart.js](https://www.chartjs.org)
 
   Support | Name | Description
   -- | -- | --
+  ! ! 4️⃣ | [a11y-legend](https://github.com/julianna-langston/chartjs-plugin-a11y-legend) | Provides keyboard accessibility for chart legends 
   ! 3️⃣ 4️⃣ | [chart2music](https://github.com/julianna-langston/chartjs2music) | Enhances chart accessibility with keyboard navigation and sonification 
   2️⃣ 3️⃣ 4️⃣ | [deferred](https://github.com/chartjs/chartjs-plugin-deferred) | Defers initial chart update until chart scrolls into viewport
   2️⃣ 3️⃣ ❕ | [dragdata](https://github.com/chrispahm/chartjs-plugin-dragdata) | Lets users drag data points on the chart


### PR DESCRIPTION
<!--
  Thank you for contributing to our awesome list!
  Please make sure you check each box below ( [x] ) after you have
  completed or verified the step. Please do not skip this template
  or your issue will be closed (and we'd rather not do that).

  Maintainers may disregard this template for organizational Pull Requests.
-->

Awesome Contribution Checklist:

<!-- *** If you do not abide by the Contributing Guidelines, your Pull Request WILL BE CLOSED -->

- [x] I have read, and re-read the [Contributing Guidelines](https://github.com/chartjs/awesome/blob/master/CONTRIBUTING.md)
- [x] I have searched to ensure the suggested item doesn't exist on this list
- [x] This PR contains only one item

### Please Describe Your Addition
This plugin helps improve the accessibility of a chart.js chart. It adds the chart legend to the tab order, and supports keyboard-only users in interacting with individual legends.

The UX for keyboard-only users works as follows:
1. The users can tab around the page, and land on the first item of the legend.
2. Users can press left/right arrow keys to navigate within the legend.
3. Users can press enter/spacebar to toggle datasets, the same as if they were using the mouse to click those legend items.

If you want to try out this UX for yourself, check out [this codepen](https://codepen.io/chart2music/full/ZEMyLVZ).

The plugin has only been written and tested with Chart.js 4, using the built-in chart types.