### PR TITLE
Add link to Symfony UX Chart.js and add description for Wicked Charts

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,8 @@ In addition, many plugins can be found on the [npm registry](https://www.npmjs.c
   2️⃣ ❕ ❕ | [liquify](https://github.com/sakos95/liquify) | Fast, multi-threaded visualization of stream data with Angular
   2️⃣ ❕ ❕ | [nova-chartjs](https://github.com/coroo/nova-chartjs) | Laravel Nova
   2️⃣ 3️⃣ 4️⃣ | [quickchart](https://github.com/typpo/quickchart) | Web API for static charts
-  2️⃣ ❕ ❕ | [wicked-charts](https://github.com/adessoAG/wicked-charts)
+  2️⃣ ❕ ❕ | [wicked-charts](https://github.com/adessoAG/wicked-charts) | Wrapper for Java web apps
+  ❕ 3️⃣ ❕ | [symfony/ux-chartjs](https://github.com/symfony/ux-chartjs) | Symfony UX bundle
 
 ## Tools
 


### PR DESCRIPTION
Awesome Contribution Checklist:

- [x] I have read, and re-read the [Contributing Guidelines](https://github.com/chartjs/awesome/blob/master/CONTRIBUTING.md)
- [x] I have searched to ensure the suggested item doesn't exist on this list
- [x] This PR contains only one item

### Please Describe Your Addition

- Added link to Symfony UX Chart.js bundle
- Added description for Wicked Charts

There is a previous PR regarding the Symfony UX bundle, #49, which was closed due to inactivity. For evidence that the Symfony UX bundle supports only Chart.js v3, see the bundle's [package.json file](https://github.com/symfony/ux/blob/2.x/src/Chartjs/assets/package.json).