### PR TITLE
Fix markdown table formatting for interaction-tools plugin entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ A curated list of awesome things related to [Chart.js](https://www.chartjs.org)
 
 ## Plugins
 
+- [interaction-tools](https://github.com/NVital14/chartjs-plugin-interaction-tools) - Drag data points and draw freeform trails directly on charts.
+
+
 ### Styling
 
   Support | Name | Description

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ A curated list of awesome things related to [Chart.js](https://www.chartjs.org)
   ❕ 3️⃣ 4️⃣ | [chart2music](https://github.com/julianna-langston/chartjs2music) | Enhances chart accessibility with keyboard navigation and sonification 
   2️⃣ 3️⃣ 4️⃣ | [deferred](https://github.com/chartjs/chartjs-plugin-deferred) | Defers initial chart update until chart scrolls into viewport
   2️⃣ 3️⃣ 4️⃣ | [dragdata](https://github.com/artus9033/chartjs-plugin-dragdata) | Lets users drag data points on the chart
-  ❕ ❕ 4️⃣ | [interaction-tools](https://github.com/NVital14/chartjs-plugin-interaction-tools) - Drag data points and draw freeform trails directly on charts.
+  ❕ ❕ 4️⃣ | [interaction-tools](https://github.com/NVital14/chartjs-plugin-interaction-tools) | Drag data points and draw freeform trails directly on charts.
   2️⃣ 3️⃣ 4️⃣ | [zoom](https://github.com/chartjs/chartjs-plugin-zoom) | Enables zooming and panning on charts
 
 

--- a/README.md
+++ b/README.md
@@ -45,9 +45,6 @@ A curated list of awesome things related to [Chart.js](https://www.chartjs.org)
 
 ## Plugins
 
-- [interaction-tools](https://github.com/NVital14/chartjs-plugin-interaction-tools) - Drag data points and draw freeform trails directly on charts.
-
-
 ### Styling
 
   Support | Name | Description
@@ -83,6 +80,7 @@ A curated list of awesome things related to [Chart.js](https://www.chartjs.org)
   2️⃣ 3️⃣ 4️⃣ | [deferred](https://github.com/chartjs/chartjs-plugin-deferred) | Defers initial chart update until chart scrolls into viewport
   2️⃣ 3️⃣ 4️⃣ | [dragdata](https://github.com/artus9033/chartjs-plugin-dragdata) | Lets users drag data points on the chart
   2️⃣ 3️⃣ 4️⃣ | [zoom](https://github.com/chartjs/chartjs-plugin-zoom) | Enables zooming and panning on charts
+  ❕ ❕ 4️⃣ | [interaction-tools](https://github.com/NVital14/chartjs-plugin-interaction-tools) - Drag data points and draw freeform trails directly on charts.
 
 ### Data Sources
 

--- a/README.md
+++ b/README.md
@@ -79,8 +79,9 @@ A curated list of awesome things related to [Chart.js](https://www.chartjs.org)
   ❕ 3️⃣ 4️⃣ | [chart2music](https://github.com/julianna-langston/chartjs2music) | Enhances chart accessibility with keyboard navigation and sonification 
   2️⃣ 3️⃣ 4️⃣ | [deferred](https://github.com/chartjs/chartjs-plugin-deferred) | Defers initial chart update until chart scrolls into viewport
   2️⃣ 3️⃣ 4️⃣ | [dragdata](https://github.com/artus9033/chartjs-plugin-dragdata) | Lets users drag data points on the chart
-  2️⃣ 3️⃣ 4️⃣ | [zoom](https://github.com/chartjs/chartjs-plugin-zoom) | Enables zooming and panning on charts
   ❕ ❕ 4️⃣ | [interaction-tools](https://github.com/NVital14/chartjs-plugin-interaction-tools) - Drag data points and draw freeform trails directly on charts.
+  2️⃣ 3️⃣ 4️⃣ | [zoom](https://github.com/chartjs/chartjs-plugin-zoom) | Enables zooming and panning on charts
+
 
 ### Data Sources
 


### PR DESCRIPTION
 Replaces `-` with `|` in the Interactions section to properly align the plugin entry in the table format.