### PR TITLE
switch to updated `chartjs-plugin-streaming` fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ A curated list of awesome things related to [Chart.js](https://www.chartjs.org)
   Support | Name | Description
   -- | -- | --
   2️⃣ 3️⃣ 4️⃣ | [datasource-prometheus](https://github.com/samber/chartjs-plugin-datasource-prometheus) | Displays time-series from Prometheus
-  2️⃣ 3️⃣ ❕ | [streaming](https://github.com/nagix/chartjs-plugin-streaming) | Adds support for live streaming data
+  2️⃣ 3️⃣ 4️⃣ | [streaming](https://github.com/Robloche/chartjs-plugin-streaming) | Adds support for live streaming data
 
 In addition, many plugins can be found on the [npm registry](https://www.npmjs.com/search?q=chartjs-plugin-).
 


### PR DESCRIPTION
<!--
  Thank you for contributing to our awesome list!
  Please make sure you check each box below ( [x] ) after you have
  completed or verified the step. Please do not skip this template
  or your issue will be closed (and we'd rather not do that).

  Maintainers may disregard this template for organizational Pull Requests.
-->

Awesome Contribution Checklist:

<!-- *** If you do not abide by the Contributing Guidelines, your Pull Request WILL BE CLOSED -->

- [x] I have read, and re-read the [Contributing Guidelines](https://github.com/chartjs/awesome/blob/master/CONTRIBUTING.md)
- [x] I have searched to ensure the suggested item doesn't exist on this list
- [x] This PR contains only one item

### Please Describe Your Addition

this simply switches the original (now unmaintained) `chartjs-plugin-streaming` entry to point to @Robloche's fork, which was updated with support for ChartJS 4.

I use this with the latest ChartJS release in a currently active webapp project, haven't experienced any issues on my side.